### PR TITLE
Address script falling back to Apple if pkg server serves over HTTP/2

### DIFF
--- a/src/loopslib/curl_requests.py
+++ b/src/loopslib/curl_requests.py
@@ -77,7 +77,7 @@ class CURL(object):
                 p_result = p_result.strip().splitlines()
 
                 for line in p_result:
-                    if re.match(r'^HTTP/\d{1}.\d{1} ', line) and ':' not in line:
+                    if re.match(r'^HTTP/\d{1}(?:[.]\d{1})? ', line) and ':' not in line:
                         result['Status'] = line
 
                         # Set the status code as a seperate value so we can minimise curl usage.
@@ -119,7 +119,7 @@ class CURL(object):
 
             # HTTP status codes should be the first three numbers of this header.
             if status:
-                result = re.sub(r'^HTTP/\d{1}.\d{1} ', '', status).split(' ')[0]
+                result = re.sub(r'^HTTP/\d{1}(?:[.]\d{1})? ', '', status).split(' ')[0]
 
         if result:
             try:


### PR DESCRIPTION
I have a local mirror of the loops hosted on a server that accepts HTTP/2 requests and cURL will attempt to connect using HTTP/2. 

When the HTTP status code is extracted from the response header for an HTTP/2 response, it fails because the regex is looking for something like "HTTP/#.# ". During deployment of the mirrored loops, the script will try to look up the status code [here](https://github.com/carlashley/appleloops/blob/7eba91fd9fe4c97b8917c9d0829998316919f80d/src/loopslib/deployment.py#L63-L77) which would be `None` and fall back to Apple's servers.

In this PR, I'm trying to account for HTTP/2 in the status code regex (but you may find a better regex as my skills are rusty). There are also similar lines in support_utils/update.py that I've left out of this PR because I figure it's intended to hit Apple's servers only and it's working fine at the moment: 
https://github.com/carlashley/appleloops/blob/e505ca40b8c890d2a6cd16f877d0b075acbf75dc/support_utils/update.py#L61
https://github.com/carlashley/appleloops/blob/e505ca40b8c890d2a6cd16f877d0b075acbf75dc/support_utils/update.py#L89