### PR TITLE
Update curl_requests.py

### DIFF
--- a/src/loopslib/curl_requests.py
+++ b/src/loopslib/curl_requests.py
@@ -44,6 +44,7 @@ class CURL(object):
                              '308 Permanent Redirect']
 
         cmd = [self._curl_path,
+               '--http1.1',
                '--user-agent',
                config.USERAGENT,
                '--silent',  # Getting headers/status should always be silent.


### PR DESCRIPTION
Forces curl to use HTTP 1.1 - fixes issue #19

I'm nowhere near competent enough to build this into the `appleloops` binary itself, but I did test this by running `__main__.py` locally. :-)